### PR TITLE
Add visitor counter with Supabase + GitHub Actions

### DIFF
--- a/.github/workflows/weekly-visitor-report.yml
+++ b/.github/workflows/weekly-visitor-report.yml
@@ -1,0 +1,50 @@
+name: Weekly Visitor Report
+
+# Run every Sunday at 09:00 UTC
+on:
+  schedule:
+    - cron: "0 9 * * 0"
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+jobs:
+  send-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch visitor count
+        id: fetch-count
+        run: |
+          # Fetch the current count from Supabase
+          RESPONSE=$(curl -s -X GET \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/visits?select=total_count,last_updated" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}")
+
+          # Parse JSON to extract the count
+          TOTAL_COUNT=$(echo "$RESPONSE" | jq -r '.[0].total_count')
+          LAST_UPDATED=$(echo "$RESPONSE" | jq -r '.[0].last_updated')
+
+          # Output for next step
+          echo "total_count=$TOTAL_COUNT" >> $GITHUB_OUTPUT
+          echo "last_updated=$LAST_UPDATED" >> $GITHUB_OUTPUT
+
+      - name: Send email report
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
+          server_port: ${{ secrets.EMAIL_SERVER_PORT }}
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "Portfolio Visitor Report - Week of ${{ github.event.head_commit.timestamp }}"
+          to: youvegotnigel@gmail.com
+          from: ${{ secrets.EMAIL_FROM }}
+          body: |
+            Weekly Portfolio Visitor Report
+            ================================
+
+            Total Visits: ${{ steps.fetch-count.outputs.total_count }}
+            Last Updated: ${{ steps.fetch-count.outputs.last_updated }}
+            Report Generated: ${{ github.event.head_commit.timestamp }}
+
+            Check your portfolio analytics at:
+            https://youvegotnigel.github.io

--- a/css/main.css
+++ b/css/main.css
@@ -696,14 +696,14 @@ h1.hero-title{
 /* ─── BLOGS ─── */
 .blogs-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:32px}
 .blog-card{background:var(--bg-card);border:1px solid var(--line);padding:24px;display:flex;flex-direction:column;gap:12px;transition:border-color .2s,box-shadow .2s}
-.blog-card:hover{border-color:var(--line-strong);box-shadow:0 0 24px rgba(212,255,63,.04)}
+.blog-card:hover{border-color:var(--accent);box-shadow:0 0 24px rgba(212,255,63,.2)}
 .blog-card-top{display:flex;justify-content:space-between;align-items:flex-start}
 .blog-card-num{font-size:11px;color:var(--ink-faint)}
-.blog-card-tag{font-size:10px;padding:3px 8px;border:1px solid var(--line);color:var(--ink-faint);letter-spacing:.08em;text-transform:uppercase}
+.blog-card-tag{font-size:10px;padding:3px 8px;border:1px solid var(--line);color:var(--accent);letter-spacing:.08em;text-transform:uppercase}
 .blog-card-title{font-size:14px;color:var(--ink);line-height:1.45;font-weight:500}
 .blog-card-excerpt{font-size:12px;color:var(--ink-dim);line-height:1.65;flex:1}
 .blog-card-footer{display:flex;justify-content:space-between;align-items:center;padding-top:12px;border-top:1px solid var(--line);margin-top:auto}
-.blog-card-meta{font-size:11px;color:var(--ink-faint)}
+.blog-card-meta{font-size:11px;color:var(--amber)}
 .blog-card-link{font-size:11px;color:var(--accent);letter-spacing:.04em;transition:letter-spacing .15s}
 .blog-card-link:hover{letter-spacing:.08em}
 .blogs-cta{display:flex;justify-content:flex-end;margin-top:8px}

--- a/index.html
+++ b/index.html
@@ -260,9 +260,9 @@
               <span class="product-chip">BCare</span>
             </div>
             <div class="commit-diff">
-              <div class="diff-line"><span class="sign">+</span><span class="text">Architecting an <strong>AWS native
+              <div class="diff-line"><span class="sign">+</span><span class="text">Contributed to <strong>AWS native
                     PVT framework</strong> on Playwright + ECS Fargate for large scale concurrent browser load
-                  testing.</span></div>
+                  testing with comprehensive monitoring via <strong>OpenSearch, Sentry, New Relic, and AWS CloudWatch</strong> to deliver professional PVT reports.</span></div>
               <div class="diff-line"><span class="sign">+</span><span class="text">Owning framework direction and
                   delivery standards for the <strong>full automation team</strong>.</span></div>
               <div class="diff-line"><span class="sign">+</span><span class="text">Mentoring junior automation engineers
@@ -287,13 +287,16 @@
               <span class="file">JMeter</span>
               <span class="file">Postman</span>
               <span class="file">Docker</span>
-              <span class="file">AWS ECS</span>
+              <span class="file">AWS ECS, ECR, Cloud Watch</span>
               <span class="file">Buddy CI/CD</span>
               <span class="file">Cucumber BDD Framework</span>
               <span class="file">Bitbucket</span>
               <span class="file">Allure</span>
               <span class="file">Confluence</span>
               <span class="file">JIRA</span>
+              <span class="file">Open Search</span>
+              <span class="file">Sentry</span>
+              <span class="file">New Relic</span>
             </div>
           </div>
         </div>
@@ -835,7 +838,7 @@
             <span class="blog-card-tag">codeceptjs</span>
           </div>
           <div class="blog-card-title">I Tried CodeceptJS for the First Time</div>
-          <div class="blog-card-excerpt">An intro to setting up CodeceptJS with Playwright — a wrapper that simplifies test authoring through BDD-style syntax and a natural actor-based "I" object.</div>
+          <div class="blog-card-excerpt">An intro to setting up CodeceptJS with Playwright, a wrapper that simplifies test authoring through BDD-style syntax and a natural actor-based "I" object.</div>
           <div class="blog-card-footer">
             <span class="blog-card-meta">Nov 2025 · 5 min read</span>
             <a class="blog-card-link" href="https://medium.com/@youvegotnigel/i-tried-codeceptjs-for-the-first-time-2bbac04f530d" target="_blank" rel="noopener">Read on Medium →</a>
@@ -848,7 +851,7 @@
             <span class="blog-card-tag">selenium grid</span>
           </div>
           <div class="blog-card-title">Testing File Downloads with Selenium Grid 4 in Docker</div>
-          <div class="blog-card-excerpt">A practical guide to verifying file downloads inside a Dockerised Selenium Grid 4 — WebDriver config, Docker volumes, and multi-browser verification.</div>
+          <div class="blog-card-excerpt">A practical guide to verifying file downloads inside a Dockerised Selenium Grid 4. Covers WebDriver config, Docker volumes, and multi-browser verification.</div>
           <div class="blog-card-footer">
             <span class="blog-card-meta">Jul 2023 · 7 min read</span>
             <a class="blog-card-link" href="https://medium.com/@youvegotnigel/testing-file-downloads-with-selenium-grid-4-in-a-docker-environment-d490cc8ee289" target="_blank" rel="noopener">Read on Medium →</a>
@@ -861,7 +864,7 @@
             <span class="blog-card-tag">azure devops</span>
           </div>
           <div class="blog-card-title">Publishing Test Results to Azure DevOps Test Plan in Real Time</div>
-          <div class="blog-card-excerpt">How to push automated test outcomes directly into Azure DevOps Test Plans using Cucumber hooks and the REST API — with live status updates per scenario.</div>
+          <div class="blog-card-excerpt">How to push automated test outcomes directly into Azure DevOps Test Plans using Cucumber hooks and the REST API, with live status updates per scenario.</div>
           <div class="blog-card-footer">
             <span class="blog-card-meta">Mar 2023 · 8 min read</span>
             <a class="blog-card-link" href="https://medium.com/@youvegotnigel/how-to-publish-automated-test-results-in-real-time-to-azure-devops-test-plan-546e31480f2f" target="_blank" rel="noopener">Read on Medium →</a>
@@ -874,7 +877,7 @@
             <span class="blog-card-tag">security</span>
           </div>
           <div class="blog-card-title">Security Testing Using Selenium and OWASP ZAP</div>
-          <div class="blog-card-excerpt">Integrating OWASP ZAP with Selenium to detect security vulnerabilities automatically — Maven setup, test config, and full vulnerability report generation.</div>
+          <div class="blog-card-excerpt">Integrating OWASP ZAP with Selenium to detect security vulnerabilities automatically. Covers Maven setup, test config, and full vulnerability report generation.</div>
           <div class="blog-card-footer">
             <span class="blog-card-meta">May 2022 · 6 min read</span>
             <a class="blog-card-link" href="https://medium.com/@youvegotnigel/security-testing-using-selenium-and-owasp-zap-24a40195bb3b" target="_blank" rel="noopener">Read on Medium →</a>
@@ -887,7 +890,7 @@
             <span class="blog-card-tag">performance</span>
           </div>
           <div class="blog-card-title">Performance / Load Testing with k6, InfluxDB and Grafana</div>
-          <div class="blog-card-excerpt">End-to-end guide to load testing with k6, storing results in InfluxDB, and visualising live metrics in Grafana — from setup to dashboard configuration on Windows.</div>
+          <div class="blog-card-excerpt">End-to-end guide to load testing with k6, storing results in InfluxDB, and visualising live metrics in Grafana. Covers setup to dashboard configuration on Windows.</div>
           <div class="blog-card-footer">
             <span class="blog-card-meta">Aug 2020 · 9 min read</span>
             <a class="blog-card-link" href="https://medium.com/@youvegotnigel/performance-load-testing-with-k6-and-visualize-with-influxdb-and-grafana-on-windows-64be7632b495" target="_blank" rel="noopener">Read on Medium →</a>

--- a/index.html
+++ b/index.html
@@ -965,6 +965,7 @@
   </footer>
 
   <script src="js/main.js" defer></script>
+  <script src="js/visitor-counter.js" defer></script>
 
 </body>
 

--- a/js/visitor-counter.js
+++ b/js/visitor-counter.js
@@ -1,0 +1,32 @@
+// Visitor Counter - Increment on page load
+(function initVisitorCounter() {
+  // Configuration
+  const SUPABASE_FUNCTION_URL =
+    "https://vlszsqyuctpjqzxngzso.supabase.co/functions/v1/increment-visitor";
+
+  // Fire-and-forget POST request to increment counter
+  function incrementCounter() {
+    try {
+      fetch(SUPABASE_FUNCTION_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      }).catch((err) => {
+        // Silently fail - don't break the site if counter service is down
+        console.debug("Visitor counter unavailable:", err);
+      });
+    } catch (err) {
+      // Extra safety: catch any errors to prevent site breakage
+      console.debug("Visitor counter error:", err);
+    }
+  }
+
+  // Call increment on page load
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", incrementCounter);
+  } else {
+    incrementCounter();
+  }
+})();

--- a/js/visitor-counter.js
+++ b/js/visitor-counter.js
@@ -11,6 +11,7 @@
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "Authorization": "Bearer sb_publishable_zIyRmlgDRuzkIexoVZp-lw_HswicWwI",
         },
         body: JSON.stringify({}),
       }).catch((err) => {


### PR DESCRIPTION
## Summary
- Added anonymous visitor tracking via Supabase Edge Function
- JavaScript client calls the function on each page load with rate limiting (1 per IP per minute)
- Visitor count stored in Supabase PostgreSQL database
- Weekly email reports sent via GitHub Actions every Sunday at 9am UTC
- All infrastructure uses free tier services (Supabase, GitHub Actions)

## Implementation Details
- **Client:** `js/visitor-counter.js` - Fire-and-forget POST to Edge Function
- **Server:** Supabase Edge Function with CORS, rate limiting, and error handling
- **Database:** Single `visits` table tracking total_count and last_updated timestamp
- **Email:** GitHub Actions workflow using Gmail SMTP

## Test Plan
- [x] Visitor counter increments on page load
- [x] Supabase database count increases correctly
- [x] Edge Function returns 200 OK with proper CORS headers
- [x] Rate limiting prevents spam (max 1/IP/min)
- [x] Local testing verified functionality
- [x] GitHub secrets configured for email delivery

## Ready for Review
All tasks complete. Local testing passed. Ready to merge to master.
