### PR TITLE
Redesign hero: replace headline with intro line and numbered specialt…

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -146,39 +146,59 @@ section{
 .hero-meta span{display:flex;align-items:center;gap:6px}
 .hero-meta .dot{width:4px;height:4px;background:var(--ink-faint);border-radius:50%}
 
-h1.hero-title{
-  font-family:var(--serif);
-  font-weight:300;
-  font-size:clamp(48px,7vw,96px);
-  line-height:.95;
-  letter-spacing:-.04em;
+.hero-intro{
+  font-size:17px;
+  line-height:1.7;
+  color:var(--ink-dim);
+  max-width:620px;
+  margin-top:-4px;
   margin-bottom:32px;
 }
-.hero-title .em{
-  font-style:italic;
-  font-weight:400;
+.hero-index{
+  max-width:660px;
+  margin-bottom:36px;
+}
+.hero-index-row{
+  display:flex;align-items:baseline;gap:24px;
+  padding:20px 0;
+  border-top:1px solid var(--line);
+}
+.hero-index-row:last-child{
+  border-bottom:1px solid var(--line);
+}
+.hero-index-num{
+  font-family:var(--mono);
+  font-size:13px;
   color:var(--accent);
+  flex-shrink:0;
 }
-.hero-title .strike{
-  position:relative;display:inline-block;
+.hero-index-body{flex:1}
+.hero-index-head{
+  display:flex;justify-content:space-between;align-items:baseline;
+  gap:16px;flex-wrap:wrap;
 }
-.hero-title .strike::after{
-  content:'';position:absolute;left:-4px;right:-4px;top:55%;height:3px;
-  background:var(--accent);
-  transform:scaleX(0);transform-origin:left;
-  animation:strike 1.2s ease-out 1.4s forwards;
-}
-@keyframes strike{to{transform:scaleX(1)}}
-
-.hero-sub{
+.hero-index-title{
   font-family:var(--serif);
-  font-size:18px;
-  color:var(--ink-dim);
-  max-width:700px;
-  margin-bottom:48px;
-  line-height:1.5;
+  font-size:28px;
+  font-weight:400;
+  color:var(--ink);
 }
-.hero-cta{display:flex;gap:16px;flex-wrap:wrap;margin-top:-24px}
+.hero-index-tags{display:flex;gap:8px}
+.hero-tag{
+  font-family:var(--mono);
+  font-size:11px;
+  color:var(--ink-dim);
+  border:1px solid var(--line-strong);
+  border-radius:20px;
+  padding:4px 10px;
+  white-space:nowrap;
+}
+.hero-index-desc{
+  font-size:14px;
+  color:var(--ink-faint);
+  margin-top:4px;
+}
+.hero-cta{display:flex;gap:16px;flex-wrap:wrap}
 .btn{
   font-family:var(--mono);
   font-size:12px;font-weight:500;

--- a/index.html
+++ b/index.html
@@ -89,16 +89,51 @@
           <span><span class="dot"></span>7+ years</span>
           <span><span class="dot"></span>SDET</span>
         </div>
-        <h1 class="hero-title">
-          I build frameworks.<br>
-          You ship <span class="em">without fear.</span>
-        </h1>
-        <p class="hero-sub">
-          I'm an ISTQB certified Test Automation Engineer with hands on experience across Web, API
-          and Mobile platforms, specialising in designing robust, scalable automation frameworks using modern open
-          source tools. I continuously explore new tools and practices to push the boundaries of what's possible in
-          modern QA.
+        <p class="hero-intro">
+          ISTQB-certified test automation engineer. I design frameworks teams keep using long
+          after I'm gone — the kind that catch regressions before your users do.
         </p>
+        <div class="hero-index">
+          <div class="hero-index-row">
+            <span class="hero-index-num">01</span>
+            <div class="hero-index-body">
+              <div class="hero-index-head">
+                <span class="hero-index-title">Framework architecture</span>
+                <span class="hero-index-tags">
+                  <span class="hero-tag">Playwright</span>
+                  <span class="hero-tag">TypeScript</span>
+                </span>
+              </div>
+              <p class="hero-index-desc">Suites teams still use years later.</p>
+            </div>
+          </div>
+          <div class="hero-index-row">
+            <span class="hero-index-num">02</span>
+            <div class="hero-index-body">
+              <div class="hero-index-head">
+                <span class="hero-index-title">CI/CD quality gates</span>
+                <span class="hero-index-tags">
+                  <span class="hero-tag">GitHub Actions</span>
+                  <span class="hero-tag">k6</span>
+                </span>
+              </div>
+              <p class="hero-index-desc">Every commit tested before it can hurt anyone.</p>
+            </div>
+          </div>
+          <div class="hero-index-row">
+            <span class="hero-index-num">03</span>
+            <div class="hero-index-body">
+              <div class="hero-index-head">
+                <span class="hero-index-title">API &amp; mobile automation</span>
+                <span class="hero-index-tags">
+                  <span class="hero-tag">REST Assured</span>
+                  <span class="hero-tag">Appium</span>
+                </span>
+              </div>
+              <p class="hero-index-desc">Contract tests and device suites beyond the browser.</p>
+            </div>
+          </div>
+        </div>
         <div class="hero-cta">
           <a href="#projects" class="btn btn-primary">View Work <span class="arrow">→</span></a>
           <a href="#contact" class="btn btn-ghost">Get in Touch <span class="arrow">↘</span></a>


### PR DESCRIPTION
…ies index

Swap the large serif headline and long intro paragraph for a short intro line plus a three-row numbered specialties index (framework architecture, CI/CD quality gates, API & mobile automation), each with an accent number, serif title, mono pill tags, and one-line description. Reuses existing tokens (--accent, --ink, --ink-dim, --ink-faint, --line, --line-strong) and fonts; nav, meta row, terminal panel, and CTA buttons are unchanged.


Claude-Session: https://claude.ai/code/session_01QbAMSXPLHkiSMnzoZi4wGi